### PR TITLE
Fix typo in heading

### DIFF
--- a/src/scenes/navbar/index.jsx
+++ b/src/scenes/navbar/index.jsx
@@ -56,7 +56,7 @@ const Navbar = () => {
             },
           }}
         >
-          Sociopedia
+          Sociopediaaa
         </Typography>
         {isNonMobileScreens && (
           <FlexBetween

--- a/src/scenes/navbar/index.jsx
+++ b/src/scenes/navbar/index.jsx
@@ -56,7 +56,7 @@ const Navbar = () => {
             },
           }}
         >
-          Sociopediaaa
+          Sociopedia
         </Typography>
         {isNonMobileScreens && (
           <FlexBetween


### PR DESCRIPTION
fixes #1

i have fixed now from 'sociopediaaa' to 'sociopedia'